### PR TITLE
Change singularity build tmpdir

### DIFF
--- a/singularity/build
+++ b/singularity/build
@@ -3,18 +3,10 @@
 recipe=$2
 image=$1
 
-if [ -d "/data" ] ; then
-    export SINGULARITY_TMPDIR=/data/shared/$USER/sbuild/
-    export SINGULARITY_CACHEDIR=/data/shared/$USER/scache/
-elif [ -d "/imdata" ] ; then
-    export SINGULARITY_TMPDIR=/imdata/$USER/sbuild/
-    export SINGULARITY_CACHEDIR=/imdata/$USER/scache/
-else
-    export SINGULARITY_TMPDIR=$HOME/sbuild/
-    export SINGULARITY_CACHEDIR=$HOME/scache/    
-fi
+export SINGULARITY_TMPDIR=/storage/user/$USER/sdir
+export SINGULARITY_CACHEDIR=/storage/user/$USER/scache/
 
 mkdir -p $SINGULARITY_TMPDIR
 mkdir -p $SINGULARITY_CACHEDIR
 
-sudo singularity build $image $recipe
+sudo singularity build --tmpdir $SINGULARITY_TMPDIR $image $recipe

--- a/singularity/build
+++ b/singularity/build
@@ -3,8 +3,16 @@
 recipe=$2
 image=$1
 
-export SINGULARITY_TMPDIR=/storage/user/$USER/sdir
-export SINGULARITY_CACHEDIR=/storage/user/$USER/scache/
+if [ -d "/data" ] ; then
+    export SINGULARITY_TMPDIR=/data/shared/$USER/sbuild/
+    export SINGULARITY_CACHEDIR=/data/shared/$USER/scache/
+elif [ -d "/imdata" ] ; then
+    export SINGULARITY_TMPDIR=/imdata/$USER/sbuild/
+    export SINGULARITY_CACHEDIR=/imdata/$USER/scache/
+else
+    export SINGULARITY_TMPDIR=$HOME/sbuild/
+    export SINGULARITY_CACHEDIR=$HOME/scache/
+fi
 
 mkdir -p $SINGULARITY_TMPDIR
 mkdir -p $SINGULARITY_CACHEDIR

--- a/singularity/cupy.singularity
+++ b/singularity/cupy.singularity
@@ -27,6 +27,7 @@ From: nvidia/cuda:10.1-cudnn7-devel-centos7
 #    pip install -U root_numpy
 
     pip install -U yappi
+    pip install -U setGPU
 
     conda install -y tensorflow-gpu keras 
     conda install -y scipy


### PR DESCRIPTION
Build will be easier if it is always pointing to `/storage`, new version of singularity needs the explicit `--tmpdir` argument.
Also update the cupy image with setGPU.